### PR TITLE
Add spec for POST and PATCH booking information

### DIFF
--- a/carpool-api-refined-en.yml
+++ b/carpool-api-refined-en.yml
@@ -1,4 +1,4 @@
-openapi: 3.0.1
+openapi: 3.0.3
 info:
   title: ""
   description: ""
@@ -115,7 +115,65 @@ paths:
                 type: integer
         500:
           description: Internal Server Error. Please try again later.
-
+  /carpoolBookings:
+    post:
+      summary: |
+        Sends new booking information of a passenger connected with a third-party provider back to the provider
+      description: |
+        Route used to allow a carpool operator to send booking information to a third-party provider. This can be used in the context of a booking flow with deeplinking and when a passenger is using the Connect specification to link their accounts of a third-party service (e.g., a MaaS) and the operator. 
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CarpoolBooking'
+      responses:
+        201:
+          description: Successful operation.
+        400:
+          description: Bad Request. See error message.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    description: |-
+                      Explain why the request couldn't be processed.
+        401:
+          description: Unauthorized. You must authenticate.
+        409:
+          description: Conflict. This booking already exists.
+        429:
+          description: Too Many Requests. Please slow down.
+          headers:
+            Retry-After:
+              description: |-
+                How long to wait before making a new request (in seconds).
+              schema:
+                type: integer
+        500:
+          description: Internal Server Error. Please try again later.
+  /carpoolBookings/{bookingId}:
+    patch:
+      summary: Updates information of an existing CarpoolBooking object.
+      parameters:
+      - name: bookingId
+        description: The id of a previously sent booking
+        in: path
+        required: true
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CarpoolBookingPatch'
+      responses: 
+        200:
+          description: Successful operation.
+        401:
+          description: Unauthorized.
+        404:
+          description: The booking no longer exists.
   /status:
     get:
       tags:
@@ -276,7 +334,79 @@ components:
           $ref: '#/components/schemas/Car'
         deepLink:
           $ref: '#/components/schemas/DeepLink'
-
+    CarpoolBookingPatch:
+      properties:
+        passengerPickupDate:
+          type: number
+          description: Passenger pickup datetime as a UNIX UTC timestamp in seconds.
+          format: long
+        passengerPickupLat:
+          type: "number"
+          format: "double"
+          description: Latitude of the passenger pick-up point.
+        passengerPickupLng:
+          type: "number"
+          format: "double"
+          description: Longitude of the passenger pick-up point.
+        passengerDropLat:
+          type: "number"
+          format: "double"
+          description: Latitude of the passenger drop-off point.
+        passengerDropLng:
+          type: "number"
+          format: "double"
+          description: Longitude of the passenger drop-off point.
+        passengerPickupAddress:
+          type: string
+          description: String representing the pickup-up address.
+        passengerDropAddress:
+          type: string
+          description: String representing the drop-off address.
+        status:
+          type: string
+          enum:
+            - WAITING_CONFIRMATION
+            - CONFIRMED
+            - CANCELLED
+            - COMPLETED_PENDING_VALIDATION
+            - VALIDATED
+        duration:
+          type: integer
+          description: Carpooling duration in seconds.
+        distance:
+          type: "integer"
+          description: |
+            Carpooling distance in meters. When the booking is COMPLETED or VALIDATED, this is the actual distance travelled if available.
+    CarpoolBooking:
+      required:
+      - id
+      - passengerId
+      - driver
+      - passengerPickupDate
+      - passengerPickupLat
+      - passengerPickupLng
+      - passengerDropLat
+      - passengerDropLng
+      - status
+      - price
+      allOf:
+        - $ref: '#/components/schemas/CarpoolBookingPatch'
+      properties:
+        id:
+          type: "string"
+          description: Unique identifier of the booking.
+        passengerId:
+          type: "string"
+          description: Identifier of the third-party passenger as returned by the Connect specification.
+        webUrl:
+          type: string
+          description: URL of the booking on the webservice provider platform.
+        price:
+          $ref: '#/components/schemas/Price'
+        driver:
+          $ref: '#/components/schemas/Driver'
+        car:
+          $ref: '#/components/schemas/Car'  
     Price:
       type: object
       properties:


### PR DESCRIPTION
In the context of a booking flow using deeplinking between a MaaS and a carpool operator, the operator may push booking information back to the MaaS. See #1 for a proposed flow.

In this PR we propose a spec for the MaaS to implement and to offer to carpool operators.